### PR TITLE
Update to poppler-0.73.0 and use docker buildkit caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,7 +125,7 @@ COPY --chown=nobody:nogroup waf wscript .
 
 RUN --mount=type=cache,src=/tmp/ccache,target=/tmp/ccache,id=ccache,from=cachebase \
     \
-    ./waf configure --static --release
+    ./waf configure --static --release || { cat build/config.log; exit 1; }
 
 RUN --mount=type=cache,src=/tmp/ccache,target=/tmp/ccache,id=ccache,from=cachebase \
     \

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ RUN --mount=type=cache,src=/tmp/ccache,target=/tmp/ccache,id=ccache,from=cacheba
           -DENABLE_CPP:BOOL=OFF \
           -DENABLE_UTILS:BOOL=OFF \
           -DBUILD_SHARED_LIBS:BOOL=OFF \
-          -DENABLE_XPDF_HEADERS:BOOL=ON \
+          -DENABLE_UNSTABLE_API_ABI_HEADERS:BOOL=ON \
           -DCMAKE_BUILD_TYPE:STRING=release \
           -DENABLE_LIBOPENJPEG:STRING=openjpeg2 \
  && make V=1 -j${BUILD_CONCURRENCY} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,23 @@
+# syntax = docker/dockerfile:experimental
+
+FROM alpine:3.8 AS cachebase
+RUN mkdir -p /tmp/ccache \
+ && chown nobody:nogroup /tmp/ccache
+
 FROM alpine:3.8
 
-RUN apk add --no-cache \
+ARG BUILD_CONCURRENCY=4
+
+RUN --mount=type=cache,target=/etc/apk/cache,id=apk-cache \
+    --mount=type=cache,target=/var/lib/apk,id=apk-lib \
+    \
+    apk add \
       autoconf \
       automake \
       build-base \
       bzip2-dev \
       cmake \
+      ccache \
       expat-dev \
       gettext-dev \
       gettext-static \
@@ -22,61 +34,72 @@ RUN apk add --no-cache \
       util-linux-dev \
       zlib-dev
 
-COPY ./vendor /src/vendor
-WORKDIR /src
-RUN chown nobody:nogroup -R /src
+ENV PATH=/usr/lib/ccache/bin:$PATH \
+    CCACHE_DIR=/tmp/ccache
 
+COPY --chown=nobody:nogroup ./vendor /src/vendor
+WORKDIR /src
 USER nobody:nogroup
 
-RUN cd vendor/git.savannah.gnu.org/r/freetype/freetype2.git/ \
+RUN --mount=type=cache,src=/tmp/ccache,target=/tmp/ccache,id=ccache,from=cachebase \
+    \
+    cd vendor/git.savannah.gnu.org/r/freetype/freetype2.git/ \
  && NOCONFIGURE=1 ./autogen.sh \
  # workaround for docker #9547 (Text file busy) \
  && sync \
  && mkdir build && cd build \
  && ../configure --prefix=$PWD/install --enable-static \
- && make -j5 \
+ && make -j${BUILD_CONCURRENCY} \
  && make install
 
-ENV PKG_CONFIG_PATH="/src/vendor/git.savannah.gnu.org/r/freetype/freetype2.git/build/install/lib/pkgconfig:$PKG_CONFIG_PATH"
-ENV LINKFLAGS="-L/src/vendor/git.savannah.gnu.org/r/freetype/freetype2.git/build/install/lib $LINKFLAGS"
-# Required for poppler cmake
-ENV FREETYPE_DIR=/src/vendor/git.savannah.gnu.org/r/freetype/freetype2.git/build/install
+ENV PKG_CONFIG_PATH="/src/vendor/git.savannah.gnu.org/r/freetype/freetype2.git/build/install/lib/pkgconfig:$PKG_CONFIG_PATH" \
+    LINKFLAGS="-L/src/vendor/git.savannah.gnu.org/r/freetype/freetype2.git/build/install/lib $LINKFLAGS" \
+    # Required for poppler cmake \
+    FREETYPE_DIR=/src/vendor/git.savannah.gnu.org/r/freetype/freetype2.git/build/install
 
 
-RUN cd vendor/anongit.freedesktop.org/git/fontconfig \
+RUN --mount=type=cache,src=/tmp/ccache,target=/tmp/ccache,id=ccache,from=cachebase \
+    \
+    cd vendor/anongit.freedesktop.org/git/fontconfig \
  && NOCONFIGURE=1 ./autogen.sh \
  && mkdir build && cd build \
  && ../configure --prefix=$PWD/install --enable-static \
- && make -j5 \
+ && make -j${BUILD_CONCURRENCY} \
  && make install
 
-ENV PKG_CONFIG_PATH="/src/vendor/anongit.freedesktop.org/git/fontconfig/build/install/lib/pkgconfig:$PKG_CONFIG_PATH"
-ENV LINKFLAGS="-L/src/vendor/anongit.freedesktop.org/git/fontconfig/build/install/lib $LINKFLAGS"
+ENV PKG_CONFIG_PATH="/src/vendor/anongit.freedesktop.org/git/fontconfig/build/install/lib/pkgconfig:$PKG_CONFIG_PATH" \
+    LINKFLAGS="-L/src/vendor/anongit.freedesktop.org/git/fontconfig/build/install/lib $LINKFLAGS"
 
 
-RUN cd vendor/github.com/mm2/Little-CMS/ \
+RUN --mount=type=cache,src=/tmp/ccache,target=/tmp/ccache,id=ccache,from=cachebase \
+    \
+    cd vendor/github.com/mm2/Little-CMS/ \
  && mkdir build && cd build \
  && ../configure --prefix=$PWD/install --enable-static \
- && make -j5 \
+ && make -j${BUILD_CONCURRENCY} \
  && make install
 
-ENV PKG_CONFIG_PATH="/src/vendor/github.com/mm2/Little-CMS/build/install/lib/pkgconfig:$PKG_CONFIG_PATH"
-ENV LINKFLAGS="-L/src/vendor/github.com/mm2/Little-CMS/build/install/lib $LINKFLAGS"
+ENV PKG_CONFIG_PATH="/src/vendor/github.com/mm2/Little-CMS/build/install/lib/pkgconfig:$PKG_CONFIG_PATH" \
+    LINKFLAGS="-L/src/vendor/github.com/mm2/Little-CMS/build/install/lib $LINKFLAGS"
 
 
-RUN cd vendor/github.com/uclouvain/openjpeg/ \
+RUN --mount=type=cache,src=/tmp/ccache,target=/tmp/ccache,id=ccache,from=cachebase \
+    \
+    cd vendor/github.com/uclouvain/openjpeg/ \
  && mkdir build && cd build \
  && cmake .. -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=$PWD/install \
- && make -j5 \
+ && make -j${BUILD_CONCURRENCY} \
  && make install
 
-ENV PKG_CONFIG_PATH="/src/vendor/github.com/uclouvain/openjpeg/build/install/lib/pkgconfig:$PKG_CONFIG_PATH"
-ENV CXXFLAGS="-I/src/vendor/github.com/uclouvain/openjpeg/build/install/include $CXXFLAGS"
-ENV LDFLAGS="-L/src/vendor/github.com/uclouvain/openjpeg/build/install/lib $LDFLAGS"
-ENV LINKFLAGS="-L/src/vendor/github.com/uclouvain/openjpeg/build/install/lib $LINKFLAGS"
+ENV PKG_CONFIG_PATH="/src/vendor/github.com/uclouvain/openjpeg/build/install/lib/pkgconfig:$PKG_CONFIG_PATH" \
+    CXXFLAGS="-I/src/vendor/github.com/uclouvain/openjpeg/build/install/include $CXXFLAGS" \
+    LDFLAGS="-L/src/vendor/github.com/uclouvain/openjpeg/build/install/lib $LDFLAGS" \
+    LINKFLAGS="-L/src/vendor/github.com/uclouvain/openjpeg/build/install/lib $LINKFLAGS"
 
 
-RUN cd vendor/anongit.freedesktop.org/git/poppler/poppler.git \
+RUN --mount=type=cache,src=/tmp/ccache,target=/tmp/ccache,id=ccache,from=cachebase \
+    \
+    cd vendor/anongit.freedesktop.org/git/poppler/poppler.git \
  && mkdir build && cd build \
  && cmake .. \
           -DCMAKE_INSTALL_PREFIX=$PWD/install \
@@ -87,22 +110,25 @@ RUN cd vendor/anongit.freedesktop.org/git/poppler/poppler.git \
           -DENABLE_XPDF_HEADERS:BOOL=ON \
           -DCMAKE_BUILD_TYPE:STRING=release \
           -DENABLE_LIBOPENJPEG:STRING=openjpeg2 \
- && make V=1 -j4 \
+ && make V=1 -j${BUILD_CONCURRENCY} \
  && make install
 
-ENV PKG_CONFIG_PATH="/src/vendor/anongit.freedesktop.org/git/poppler/poppler.git/build/install/lib64/pkgconfig:$PKG_CONFIG_PATH"
-ENV LINKFLAGS="-L/src/vendor/anongit.freedesktop.org/git/poppler/poppler.git/build/install/lib64 $LINKFLAGS"
-ENV CXXFLAGS="-I/src/vendor/anongit.freedesktop.org/git/poppler/poppler.git/build/install/include $CXXFLAGS"
+ENV PKG_CONFIG_PATH="/src/vendor/anongit.freedesktop.org/git/poppler/poppler.git/build/install/lib64/pkgconfig:$PKG_CONFIG_PATH" \
+    LINKFLAGS="-L/src/vendor/anongit.freedesktop.org/git/poppler/poppler.git/build/install/lib64 $LINKFLAGS" \
+    CXXFLAGS="-I/src/vendor/anongit.freedesktop.org/git/poppler/poppler.git/build/install/include $CXXFLAGS"
 
 
-COPY ./src /src/src
-COPY waf waf
-COPY msgpack-c msgpack-c
-COPY wscript wscript
+COPY --chown=nobody:nogroup ./src /src/src
+COPY --chown=nobody:nogroup msgpack-c msgpack-c
 
+COPY --chown=nobody:nogroup waf wscript .
 
-RUN ./waf configure --static --release
-RUN ./waf build
+RUN --mount=type=cache,src=/tmp/ccache,target=/tmp/ccache,id=ccache,from=cachebase \
+    \
+    ./waf configure --static --release
 
+RUN --mount=type=cache,src=/tmp/ccache,target=/tmp/ccache,id=ccache,from=cachebase \
+    \
+    ./waf build
 
 ENTRYPOINT ["/src/build/pdf2msgpack"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,8 @@ RUN --mount=type=cache,src=/tmp/ccache,target=/tmp/ccache,id=ccache,from=cacheba
 ENV PKG_CONFIG_PATH="/src/vendor/github.com/uclouvain/openjpeg/build/install/lib/pkgconfig:$PKG_CONFIG_PATH" \
     CXXFLAGS="-I/src/vendor/github.com/uclouvain/openjpeg/build/install/include $CXXFLAGS" \
     LDFLAGS="-L/src/vendor/github.com/uclouvain/openjpeg/build/install/lib $LDFLAGS" \
-    LINKFLAGS="-L/src/vendor/github.com/uclouvain/openjpeg/build/install/lib $LINKFLAGS"
+    LINKFLAGS="-L/src/vendor/github.com/uclouvain/openjpeg/build/install/lib $LINKFLAGS" \
+    OpenJPEG_DIR="/src/vendor/github.com/uclouvain/openjpeg/build/install/lib/openjpeg-2.3"
 
 
 RUN --mount=type=cache,src=/tmp/ccache,target=/tmp/ccache,id=ccache,from=cachebase \
@@ -120,7 +121,6 @@ ENV PKG_CONFIG_PATH="/src/vendor/anongit.freedesktop.org/git/poppler/poppler.git
 
 COPY --chown=nobody:nogroup ./src /src/src
 COPY --chown=nobody:nogroup msgpack-c msgpack-c
-
 COPY --chown=nobody:nogroup waf wscript .
 
 RUN --mount=type=cache,src=/tmp/ccache,target=/tmp/ccache,id=ccache,from=cachebase \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ pdf2msgpack.dbg: build-container
 	@echo "Wrote pdf2msgpack.dbg"
 
 build-container: Dockerfile src/main.cpp
-	docker build -t pdf2msgpack .
+	DOCKER_BUILDKIT=1 docker build -t pdf2msgpack .
 
 release: pdf2msgpack
 	./release.sh

--- a/src/DumpAsTextDev.h
+++ b/src/DumpAsTextDev.h
@@ -96,12 +96,12 @@ public:
     return OutputDev::cvtUserToDev(ux, uy, dx, dy);
   }
 
-  double *getDefCTM() {
+  const double *getDefCTM() {
     printf("getDefCTM\n");
     return OutputDev::getDefCTM();
   }
 
-  double *getDefICTM() {
+  const double *getDefICTM() {
     printf("getDefICTM\n");
     return OutputDev::getDefICTM();
   }

--- a/src/DumpAsTextDev.h
+++ b/src/DumpAsTextDev.h
@@ -9,46 +9,46 @@
 // (Or see poppler/OutputDev.h).
 class DumpAsTextDev : public OutputDev {
 public:
-  GBool upsideDown() { return gTrue; }
+  bool upsideDown() { return true; }
 
-  GBool useDrawChar() { return gTrue; }
+  bool useDrawChar() { return true; }
 
-  GBool useTilingPatternFill() {
+  bool useTilingPatternFill() {
     printf("useTilingPatternFill\n");
     return OutputDev::useTilingPatternFill();
   }
 
-  GBool useShadedFills(int type) {
+  bool useShadedFills(int type) {
     printf("useShadedFills\n");
     return OutputDev::useShadedFills(type);
   }
 
-  GBool useFillColorStop() {
+  bool useFillColorStop() {
     printf("useFillColorStop\n");
     return OutputDev::useFillColorStop();
   }
 
-  GBool useDrawForm() {
+  bool useDrawForm() {
     printf("useDrawForm\n");
     return OutputDev::useDrawForm();
   }
 
-  GBool interpretType3Chars() {
+  bool interpretType3Chars() {
     printf("interpretType3Chars\n");
-    return gTrue;
+    return true;
   }
 
-  GBool needNonText() {
+  bool needNonText() {
     printf("needNonText\n");
     return OutputDev::needNonText();
   }
 
-  GBool needCharCount() {
+  bool needCharCount() {
     printf("needCharCount\n");
     return OutputDev::needCharCount();
   }
 
-  GBool needClipToCropBox() {
+  bool needClipToCropBox() {
     printf("needClipToCropBox\n");
     return OutputDev::needClipToCropBox();
   }
@@ -58,11 +58,11 @@ public:
     return OutputDev::setDefaultCTM(ctm);
   }
 
-  GBool checkPageSlice(Page *page, double hDPI, double vDPI, int rotate,
-                       GBool useMediaBox, GBool crop, int sliceX, int sliceY,
-                       int sliceW, int sliceH, GBool printing,
-                       GBool (*abortCheckCbk)(void *), void *abortCheckCbkData,
-                       GBool (*annotDisplayDecideCbk)(Annot *, void *),
+  bool checkPageSlice(Page *page, double hDPI, double vDPI, int rotate,
+                       bool useMediaBox, bool crop, int sliceX, int sliceY,
+                       int sliceW, int sliceH, bool printing,
+                       bool (*abortCheckCbk)(void *), void *abortCheckCbkData,
+                       bool (*annotDisplayDecideCbk)(Annot *, void *),
                        void *annotDisplayDecideCbkData) {
     printf("checkPageSlice\n");
     return OutputDev::checkPageSlice(
@@ -314,7 +314,7 @@ public:
     return OutputDev::eoFill(A);
   }
 
-  GBool tilingPatternFill(GfxState *A, Gfx *B, Catalog *C, Object *D, double *E,
+  bool tilingPatternFill(GfxState *A, Gfx *B, Catalog *C, Object *D, double *E,
                           int F, int G, Dict *H, double *I, double *J, int K,
                           int L, int M, int N, double O, double P) {
     printf("tilingPatternFill\n");
@@ -322,38 +322,38 @@ public:
                                         N, O, P);
   }
 
-  GBool functionShadedFill(GfxState *A, GfxFunctionShading *B) {
+  bool functionShadedFill(GfxState *A, GfxFunctionShading *B) {
     printf("functionShadedFill\n");
     return OutputDev::functionShadedFill(A, B);
   }
 
-  GBool axialShadedFill(GfxState *A, GfxAxialShading *B, double C, double D) {
+  bool axialShadedFill(GfxState *A, GfxAxialShading *B, double C, double D) {
     printf("axialShadedFill\n");
     return OutputDev::axialShadedFill(A, B, C, D);
   }
 
-  GBool axialShadedSupportExtend(GfxState *A, GfxAxialShading *B) {
+  bool axialShadedSupportExtend(GfxState *A, GfxAxialShading *B) {
     printf("axialShadedSupportExtend\n");
     return OutputDev::axialShadedSupportExtend(A, B);
   }
 
-  GBool radialShadedFill(GfxState *A, GfxRadialShading *B, double C, double D) {
+  bool radialShadedFill(GfxState *A, GfxRadialShading *B, double C, double D) {
     printf("radialShadedFill\n");
     return OutputDev::radialShadedFill(A, B, C, D);
   }
 
-  GBool radialShadedSupportExtend(GfxState *A, GfxRadialShading *B) {
+  bool radialShadedSupportExtend(GfxState *A, GfxRadialShading *B) {
     printf("radialShadedSupportExtend\n");
     return OutputDev::radialShadedSupportExtend(A, B);
   }
 
-  GBool gouraudTriangleShadedFill(GfxState *state,
+  bool gouraudTriangleShadedFill(GfxState *state,
                                   GfxGouraudTriangleShading *shading) {
     printf("gouraudTriangleShadedFill\n");
     return OutputDev::gouraudTriangleShadedFill(state, shading);
   }
 
-  GBool patchMeshShadedFill(GfxState *state, GfxPatchMeshShading *shading) {
+  bool patchMeshShadedFill(GfxState *state, GfxPatchMeshShading *shading) {
     printf("patchMeshShadedFill\n");
     return OutputDev::patchMeshShadedFill(state, shading);
   }
@@ -406,7 +406,7 @@ public:
     return OutputDev::drawString(A, B);
   }
 
-  GBool beginType3Char(GfxState *A, double B, double C, double D, double E,
+  bool beginType3Char(GfxState *A, double B, double C, double D, double E,
                        CharCode F, Unicode *G, int H) {
     printf("beginType3Char\n");
     return OutputDev::beginType3Char(A, B, C, D, E, F, G, H);
@@ -443,16 +443,16 @@ public:
   }
 
   void drawImageMask(GfxState *state, Object *ref, Stream *str, int width,
-                     int height, GBool invert, GBool interpolate,
-                     GBool inlineImg) {
+                     int height, bool invert, bool interpolate,
+                     bool inlineImg) {
     printf("drawImageMask\n");
     return OutputDev::drawImageMask(state, ref, str, width, height, invert,
                                     interpolate, inlineImg);
   }
 
   void setSoftMaskFromImageMask(GfxState *state, Object *ref, Stream *str,
-                                int width, int height, GBool invert,
-                                GBool inlineImg, double *baseMatrix) {
+                                int width, int height, bool invert,
+                                bool inlineImg, double *baseMatrix) {
     printf("setSoftMaskFromImageMask\n");
     return OutputDev::setSoftMaskFromImageMask(state, ref, str, width, height,
                                                invert, inlineImg, baseMatrix);
@@ -464,8 +464,8 @@ public:
   }
 
   void drawImage(GfxState *state, Object *ref, Stream *str, int width,
-                 int height, GfxImageColorMap *colorMap, GBool interpolate,
-                 int *maskColors, GBool inlineImg) {
+                 int height, GfxImageColorMap *colorMap, bool interpolate,
+                 int *maskColors, bool inlineImg) {
     printf("drawImage\n");
     return OutputDev::drawImage(state, ref, str, width, height, colorMap,
                                 interpolate, maskColors, inlineImg);
@@ -473,9 +473,9 @@ public:
 
   void drawMaskedImage(GfxState *state, Object *ref, Stream *str, int width,
                        int height, GfxImageColorMap *colorMap,
-                       GBool interpolate, Stream *maskStr, int maskWidth,
-                       int maskHeight, GBool maskInvert,
-                       GBool maskInterpolate) {
+                       bool interpolate, Stream *maskStr, int maskWidth,
+                       int maskHeight, bool maskInvert,
+                       bool maskInterpolate) {
     printf("drawMaskedImage\n");
     return OutputDev::drawMaskedImage(state, ref, str, width, height, colorMap,
                                       interpolate, maskStr, maskWidth,
@@ -484,9 +484,9 @@ public:
 
   void drawSoftMaskedImage(GfxState *state, Object *ref, Stream *str, int width,
                            int height, GfxImageColorMap *colorMap,
-                           GBool interpolate, Stream *maskStr, int maskWidth,
+                           bool interpolate, Stream *maskStr, int maskWidth,
                            int maskHeight, GfxImageColorMap *maskColorMap,
-                           GBool maskInterpolate) {
+                           bool maskInterpolate) {
     printf("drawSoftMaskedImage\n");
     return OutputDev::drawSoftMaskedImage(
         state, ref, str, width, height, colorMap, interpolate, maskStr,
@@ -544,13 +544,13 @@ public:
     return OutputDev::psXObject(A, B);
   }
 
-  GBool checkTransparencyGroup(GfxState *A, GBool B) {
+  bool checkTransparencyGroup(GfxState *A, bool B) {
     printf("checkTransparencyGroup\n");
     return OutputDev::checkTransparencyGroup(A, B);
   }
 
-  void beginTransparencyGroup(GfxState *A, double *B, GfxColorSpace *C, GBool D,
-                              GBool E, GBool F) {
+  void beginTransparencyGroup(GfxState *A, double *B, GfxColorSpace *C, bool D,
+                              bool E, bool F) {
     printf("beginTransparencyGroup\n");
     return OutputDev::beginTransparencyGroup(A, B, C, D, E, F);
   }
@@ -565,7 +565,7 @@ public:
     return OutputDev::paintTransparencyGroup(A, B);
   }
 
-  void setSoftMask(GfxState *A, double *B, GBool C, Function *D, GfxColor *E) {
+  void setSoftMask(GfxState *A, double *B, bool C, Function *D, GfxColor *E) {
     printf("setSoftMask\n");
     return OutputDev::setSoftMask(A, B, C, D, E);
   }
@@ -580,12 +580,12 @@ public:
     return OutputDev::processLink(A);
   }
 
-  GBool getVectorAntialias() {
+  bool getVectorAntialias() {
     printf("getVectorAntialias\n");
     return OutputDev::getVectorAntialias();
   }
 
-  void setVectorAntialias(GBool A) {
+  void setVectorAntialias(bool A) {
     printf("setVectorAntialias\n");
     return OutputDev::setVectorAntialias(A);
   }

--- a/src/DumpPathsAsMsgPackDev.h
+++ b/src/DumpPathsAsMsgPackDev.h
@@ -106,9 +106,9 @@ public:
     out << buffer.str();
   }
 
-  GBool upsideDown() { return gTrue; }
-  GBool useDrawChar() { return gTrue; }
-  GBool interpretType3Chars() { return gTrue; }
+  bool upsideDown() { return true; }
+  bool useDrawChar() { return true; }
+  bool interpretType3Chars() { return true; }
 
   void eoFill(GfxState *state) {
     doPath(state, state->getCTM(), state->getPath(), EO_FILL);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -393,7 +393,7 @@ void dump_page_glyphs(Page *page) {
   int n_lines;
   auto deleter = [&](GooList **lines) {
     for (int i = 0; i < n_lines; i++) {
-      deleteGooList(lines[i], TextWordSelection);
+      deleteGooList<TextWordSelection>(lines[i]);
     }
     gfree(lines);
   };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -176,13 +176,13 @@ void dump_font_info(PDFDoc *doc) {
     packer.pack_map(6);
 
     packer.pack("Name");
-    packer.pack(font->getName() ? font->getName()->getCString() : "[none]");
+    packer.pack(font->getName() ? font->getName()->toStr() : "[none]");
 
     packer.pack("Type");
     packer.pack(fontTypeNames[font->getType()]);
 
     packer.pack("Encoding");
-    packer.pack(font->getEncoding()->getCString());
+    packer.pack(font->getEncoding()->toStr());
 
     packer.pack("Embedded");
     packer.pack(font->getEmbedded());
@@ -203,14 +203,14 @@ void pack_stream_content(Stream *stream) {
   stream->close();
 
   packer.pack_bin(content.getLength());
-  packer.pack_bin_body(content.getCString(), content.getLength());
+  packer.pack_bin_body(content.toStr().c_str(), content.getLength());
 }
 
 void pack_string(const GooString *string) {
   if (!string || string->getLength() <= 0)
     packer.pack_nil();
   else
-    packer.pack(string->getCString());
+    packer.pack(string->toStr());
 }
 
 void dump_meta_xfa(Catalog *catalog, UnicodeMap *uMap) {
@@ -311,12 +311,12 @@ void TextPageDecRef(TextPage *text_page) { text_page->decRefCnt(); }
 typedef std::unique_ptr<TextPage, decltype(&TextPageDecRef)> TextPagePtr;
 
 TextPagePtr page_to_text_page(Page *page) {
-  auto dev = std::make_unique<TextOutputDev>(nullptr, gTrue, 0, gFalse, gFalse);
+  auto dev = std::make_unique<TextOutputDev>(nullptr, true, 0, false, false);
 
   auto gfx = std::unique_ptr<Gfx>(
-      page->createGfx(dev.get(), 72.0, 72.0, 0, gFalse, /* useMediaBox */
-                      gTrue,                            /* Crop */
-                      -1, -1, -1, -1, gFalse,           /* printing */
+      page->createGfx(dev.get(), 72.0, 72.0, 0, false, /* useMediaBox */
+                      true,                            /* Crop */
+                      -1, -1, -1, -1, false,           /* printing */
                       NULL, NULL));
 
   page->display(gfx.get());
@@ -411,9 +411,9 @@ void dump_page_paths(Page *page) {
   auto dev = std::make_unique<DumpPathsAsMsgPackDev>();
 
   auto gfx = std::unique_ptr<Gfx>(
-      page->createGfx(dev.get(), 72.0, 72.0, 0, gFalse, /* useMediaBox */
-                      gTrue,                            /* Crop */
-                      -1, -1, -1, -1, gFalse,           /* printing */
+      page->createGfx(dev.get(), 72.0, 72.0, 0, false, /* useMediaBox */
+                      true,                            /* Crop */
+                      -1, -1, -1, -1, false,           /* printing */
                       NULL, NULL));
 
   page->display(gfx.get());
@@ -435,8 +435,8 @@ void dump_page_bitmap(Page *page) {
   // auto mode = splashModeRGB8;
   // const auto n_channels = 3;
 
-  auto dev = std::make_unique<SplashOutputDev>(mode, 4, gFalse, paperColor,
-                                               gTrue, splashThinLineShape);
+  auto dev = std::make_unique<SplashOutputDev>(mode, 4, false, paperColor,
+                                               true, splashThinLineShape);
 
   dev->setFontAntialias(true);
   dev->setVectorAntialias(true);
@@ -446,9 +446,9 @@ void dump_page_bitmap(Page *page) {
                 // TODO(pwaller): Parameterize resolution.
                 72.0 / 8, 72.0 / 8,
                 0,      // rotate
-                gFalse, /* useMediaBox */
-                gFalse, /* Crop */
-                gFalse, /* printing */
+                false, /* useMediaBox */
+                false, /* Crop */
+                false, /* printing */
                 NULL, NULL);
 
   auto bitmap = dev->getBitmap();
@@ -506,7 +506,7 @@ BaseStream *open_file(const std::string filename) {
     exit(5);
   }
   Object obj;
-  return new FileStream(file, 0, gFalse, file->size(), Object(objNull));
+  return new FileStream(file, 0, false, file->size(), Object(objNull));
 }
 
 std::string parse_page_range(std::string value, Options *options) {

--- a/wscript
+++ b/wscript
@@ -84,7 +84,7 @@ def configure(ctx):
     # /usr/include/poppler/...
     ctx.check_cxx(header_name="PDFDoc.h", use="poppler",
                   msg="Checking libpoppler-private-dev (poppler configured " +
-                      "with --enable-xpdf-headers)")
+                      "with ENABLE_UNSTABLE_API_ABI_HEADERS=ON)")
 
     if ctx.options.enable_syscall_reporter:
         ctx.env.append_value("CXXFLAGS", ["-DENABLE_SYSCALL_REPORTER"])


### PR DESCRIPTION
This PR updates to poppler-0.73.0. We do it via 0.70.1 since .71 was invasive.

This could do with a bit of additional testing.