### PR TITLE
Update Freetype Git URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vendor/git.savannah.gnu.org/r/freetype/freetype2.git"]
 	path = vendor/git.savannah.gnu.org/r/freetype/freetype2.git
-	url = https://git.savannah.gnu.org/r/freetype/freetype2.git
+	url = https://gitlab.freedesktop.org/freetype/freetype.git
 [submodule "vendor/anongit.freedesktop.org/git/fontconfig"]
 	path = vendor/anongit.freedesktop.org/git/fontconfig
 	url = https://anongit.freedesktop.org/git/fontconfig

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
-[submodule "vendor/git.savannah.gnu.org/r/freetype/freetype2.git"]
-	path = vendor/git.savannah.gnu.org/r/freetype/freetype2.git
+[submodule "vendor/gitlab.freedesktop.org/freetype/freetype.git"]
+	path = vendor/gitlab.freedesktop.org/freetype/freetype.git
 	url = https://gitlab.freedesktop.org/freetype/freetype.git
 [submodule "vendor/anongit.freedesktop.org/git/fontconfig"]
 	path = vendor/anongit.freedesktop.org/git/fontconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ USER nobody:nogroup
 
 RUN --mount=type=cache,src=/tmp/ccache,target=/tmp/ccache,id=ccache,from=cachebase \
     \
-    cd vendor/git.savannah.gnu.org/r/freetype/freetype2.git/ \
+    cd vendor/gitlab.freedesktop.org/freetype/freetype.git/ \
  && NOCONFIGURE=1 ./autogen.sh \
  # workaround for docker #9547 (Text file busy) \
  && sync \
@@ -54,10 +54,10 @@ RUN --mount=type=cache,src=/tmp/ccache,target=/tmp/ccache,id=ccache,from=cacheba
  && make -j${BUILD_CONCURRENCY} \
  && make install
 
-ENV PKG_CONFIG_PATH="/src/vendor/git.savannah.gnu.org/r/freetype/freetype2.git/build/install/lib/pkgconfig:$PKG_CONFIG_PATH" \
-    LINKFLAGS="-L/src/vendor/git.savannah.gnu.org/r/freetype/freetype2.git/build/install/lib $LINKFLAGS" \
+ENV PKG_CONFIG_PATH="/src/vendor/gitlab.freedesktop.org/freetype/freetype.git/build/install/lib/pkgconfig:$PKG_CONFIG_PATH" \
+    LINKFLAGS="-L/src/vendor/gitlab.freedesktop.org/freetype/freetype.git/build/install/lib $LINKFLAGS" \
     # Required for poppler cmake \
-    FREETYPE_DIR=/src/vendor/git.savannah.gnu.org/r/freetype/freetype2.git/build/install
+    FREETYPE_DIR=/src/vendor/gitlab.freedesktop.org/freetype/freetype.git/build/install
 
 
 RUN --mount=type=cache,src=/tmp/ccache,target=/tmp/ccache,id=ccache,from=cachebase \


### PR DESCRIPTION
The resource moved, so we should update to the canonical URL.

The existing URL does apparently still work, but may also be causing problems for Dependabot, so let's try updating it.