### PR TITLE
Fix output non-determinism

### DIFF
--- a/src/DumpPathsAsMsgPackDev.h
+++ b/src/DumpPathsAsMsgPackDev.h
@@ -179,7 +179,16 @@ public:
 
       std::vector<PathPoint> path_points;
       while (j < m) {
-        if (subpath->getCurve(j)) {
+        // Consider removing the bounds end check: j < m - 2
+        // This should not be necessary with the j += 2 increment,
+        // but is an extra safeguard to ensure we do not end up accessing
+        // the uninitialised part of arrays.
+        // If the number of points, m, is, say, 10,
+        // we need to stop at point 8 to ensure we don't exceed point 10
+        // because we access the second value beyond 8.
+        // This actually corresponds to j = 7 as j is 0-indexed,
+        // that is, j must be less than m - 2.
+        if (subpath->getCurve(j) && (j < m - 2)) {
           auto a = transform.mul(subpath->getX(j + 0), subpath->getY(j + 0)),
                b = transform.mul(subpath->getX(j + 1), subpath->getY(j + 1)),
                c = transform.mul(subpath->getX(j + 2), subpath->getY(j + 2));

--- a/src/DumpPathsAsMsgPackDev.h
+++ b/src/DumpPathsAsMsgPackDev.h
@@ -185,13 +185,26 @@ public:
                c = transform.mul(subpath->getX(j + 2), subpath->getY(j + 2));
 
           path_points.push_back(PathPoint(a.x, a.y, b.x, b.y, c.x, c.y));
+          // Consider replacing this with j += 3 in future.
+          // See the associated commit message or #154 for a full explanation.
+          // Poppler's own code iterates using j += 3 for subpath curves.
+          //
+          // This is a hack to keep the behaviour of pdf2msgpack close to what it was,
+          // but with reproducible output.
+          // The current result is that the first point of the curve gets acted on as previously,
+          // the second point of the curve no longer incorrectly adds another curve point,
+          // but the final point does get included as a standalone point
+          // (the final point also gets handled by the else block below).
+          // Including the final point as a standalone point may not be strictly correct,
+          // but more closely retains the previous behaviour.
+          j += 2;
         } else {
           auto x = subpath->getX(j), y = subpath->getY(j);
 
           auto t = transform.mul(x, y);
           path_points.push_back(PathPoint(t.x, t.y));
+          ++j;
         }
-        ++j;
       }
 
       if (!path_points.empty()) {


### PR DESCRIPTION
Fixes #154.

With this fix, the outputs are deterministic. Without it, in some cases, the outputs are not; for example, they can be very, very small, random floating point values.

In brief, this is because when handling curve subpaths, the code accesses values from subsequent positions in arrays. Poppler represents curves as three successive values; the first two have `curve=true` and the third one `curve=false`.

The code here is similar to that Poppler uses it for iterating through these values in its own `doPath` code. However,  when working with curve values, Poppler's own code then works with a loop increment of `+= 3`. This ensures that only the first point of the curve is handled.

The fundamental problem is that the code accesses the second subsequent array value after `curve=true` (used in `getX()` and `getY()`).

And you don't get the situation where you're at the end of the initialised array values:

`[…curve1, curve2, curve3, uninitialised_value1, …]`

and trying to access `current position + 2` from `curve2` spills over into the uninitialised array values

There are two main problems here:

* the end of array problem, which most likely gives rise to the non-deterministic output
* the issue that even earlier in the array, where values are initialised, the second value of a curve subpath, will end up creating a curve value using subsequent values that are not actually part of the same curve

The array values at least exist, because Poppler expands these arrays when they are filled, but they are not initialised. Presumably what the resulting values are depends on undefined behaviour, which gives rise to inconsistent outputs.

The fix is to increment the loop to avoid this, and to add an extra, possibly unnecessary check, for the end of the valid value positions when handling curves.

There is a remaining problem, which is that the final `curve=true` value possibly shouldn't be included as a regular point. But leaving that as is for now, for consistency with the previous output. In future, I think the correct thing is to use `j += 3` again when `getCurve()=true`.

Whether the [original change of the loop handling was intentional or a bug](https://github.com/sensiblecodeio/pdf2msgpack/pull/10), I'm not entirely sure as to the intent.

See the issue, code comments, and commit messages for more details and explanation.