### PR TITLE
Restore msgpack v4.1.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,4 @@
 [submodule "vendor/github.com/msgpack/msgpack-c"]
 	path = vendor/github.com/msgpack/msgpack-c
 	url = https://github.com/msgpack/msgpack-c
+	branch = cpp_master

--- a/wscript
+++ b/wscript
@@ -45,6 +45,7 @@ def configure(ctx):
         "-Werror",
         "-ansi",
         "--std=c++14",
+        "-DMSGPACK_NO_BOOST",
     ])
 
     need_syscall_filter = not ctx.options.disable_syscall_filter


### PR DESCRIPTION
This has been previously upgraded to, then reverted. This PR undoes the relevant reverts to apply these commits again.