### PR TITLE
Update to Poppler 24.01.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,12 @@ RUN --mount=type=cache,src=/tmp/ccache,target=/tmp/ccache,id=ccache,from=cacheba
           -DENABLE_UNSTABLE_API_ABI_HEADERS:BOOL=ON \
           -DCMAKE_BUILD_TYPE:STRING=release \
           -DENABLE_LIBOPENJPEG:STRING=openjpeg2 \
+          -DENABLE_NSS3:BOOL=OFF \
+          -DENABLE_GPGME:BOOL=OFF \
+          -DENABLE_LIBTIFF:BOOL=OFF \
+          -DENABLE_QT5:BOOL=OFF \
+          -DENABLE_QT6:BOOL=OFF \
+          -DENABLE_LIBCURL:BOOL=OFF \
  && make V=1 -j${BUILD_CONCURRENCY} \
  && make install
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -308,8 +308,7 @@ void TextPageDecRef(TextPage *text_page) { text_page->decRefCnt(); }
 void render_annotations(std::unique_ptr<Gfx> &gfx, Annots *annots) {
   gfx->saveState();
 
-  for (auto i = 0; i < annots->getNumAnnots(); i++) {
-    auto *annot = annots->getAnnot(i);
+  for (Annot *annot : annots->getAnnots()) {
     annot->draw(gfx.get(), false);
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -520,13 +520,13 @@ void dump_document(PDFDoc *doc, const Options &options) {
 }
 
 BaseStream *open_file(const std::string filename) {
-  auto file = GooFile::open(filename);
+  std::unique_ptr<GooFile> file = GooFile::open(filename);
   if (file == NULL) {
     std::cerr << "Failed to open " << filename << std::endl;
     exit(5);
   }
   Object obj;
-  return new FileStream(file, 0, false, file->size(), Object(objNull));
+  return new FileStream(file.release(), 0, false, file->size(), Object(objNull));
 }
 
 std::string parse_page_range(std::string value, Options *options) {


### PR DESCRIPTION
This finally gets us to the current version of Poppler; albeit with the need for two reverted commits.